### PR TITLE
Add Ollama option and job overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Firefly III AI categorization
 
 This project allows you to automatically categorize your expenses in [Firefly III](https://www.firefly-iii.org/) by
-using OpenAI.
+using OpenAI or a self-hosted Ollama model.
 
 ## Please fork me
 Unfortunately i am not able to invest more time into maintaining this project. 
@@ -12,10 +12,10 @@ Feel free to fork it and create a PR that adds a link to your fork in the README
 
 It provides a webhook that you can set up to be called every time a new expense is added.
 
-It will then generate a prompt for OpenAI, including your existing categories, the recipient and the description of the
-transaction.
+It will then generate a prompt for the configured Large Language Model (LLM), including your existing categories, the
+recipient and the description of the transaction.
 
-OpenAI will, based on that prompt, guess the category for the transaction.
+The LLM will, based on that prompt, guess the category for the transaction.
 
 If it is one of your existing categories, the tool will set the category on the transaction and also add a tag to the
 transaction.
@@ -24,13 +24,22 @@ If it cannot detect the category, it will not update anything.
 
 ## Privacy
 
-Please note that some details of the transactions will be sent to OpenAI as information to guess the category.
+Please note that some details of the transactions will be sent to the LLM as information to guess the category.
 
-These are:
+When using the OpenAI integration, the following fields are shared:
 
 - Transaction description
 - Name of transaction destination account
 - Names of all categories
+
+When using a self-hosted Ollama instance the following additional information is shared to improve the quality of the
+classification:
+
+- Transaction amount and currency
+- Transaction date
+- Source account name (if available)
+- Existing notes, payment references, linked bill and budget names
+- Tags already attached to the transaction
 
 ## Installation
 
@@ -45,9 +54,10 @@ like Notepad++ or Visual Studio Code to copy-and-paste it.
 ![Step 2](docs/img/pat2.png)
 ![Step 3](docs/img/pat3.png)
 
-### 2. Get an OpenAI API Key
+### 2. Choose an LLM provider
 
-The project needs to be configured with your OpenAI account's secret key.
+By default the application uses OpenAI. Follow the steps below to obtain an API key if you want to keep using the hosted
+OpenAI service.
 
 - Sign up for an account by going to the OpenAI website (https://platform.openai.com)
 - Once an account is created, visit the API keys page at https://platform.openai.com/account/api-keys.
@@ -63,6 +73,10 @@ payment details to begin interacting with the API for the first time.
 After that you have to enable billing in your account.
 
 Tip: Make sure to set budget limits to prevent suprises at the end of the month.
+
+If you prefer to use a self-hosted model, install [Ollama](https://ollama.com) on a machine you control and pull your
+preferred model (for example `gpt-oss:20b`). Set the environment variable `LLM_PROVIDER=ollama` and optionally adjust
+`OLLAMA_URL` (defaults to `http://localhost:11434`) and `OLLAMA_MODEL` (defaults to `gpt-oss:20b`).
 
 ### 3. Start the application via Docker
 
@@ -83,6 +97,10 @@ services:
       FIREFLY_URL: "https://firefly.example.com"
       FIREFLY_PERSONAL_TOKEN: "eyabc123..."
       OPENAI_API_KEY: "sk-abc123..."
+#     Uncomment the lines below to use a self-hosted Ollama instance instead of OpenAI
+#     LLM_PROVIDER: "ollama"
+#     OLLAMA_URL: "http://ollama:11434"
+#     OLLAMA_MODEL: "gpt-oss:20b"
 ```
 
 Make sure to set the environment variables correctly.
@@ -152,7 +170,10 @@ If you have to run the application on a different port than the default port `30
 
 - `FIREFLY_URL`: The URL to your Firefly III instance. Example: `https://firefly.example.com`. (required)
 - `FIREFLY_PERSONAL_TOKEN`: A Firefly III Personal Access Token. (required)
-- `OPENAI_API_KEY`: The OpenAI API Key to authenticate against OpenAI. (required)
+- `OPENAI_API_KEY`: The OpenAI API Key to authenticate against OpenAI. (Required when `LLM_PROVIDER=openai`)
+- `LLM_PROVIDER`: Which LLM backend to use. Supported values: `openai` (default) or `ollama`.
+- `OLLAMA_URL`: Base URL of the Ollama service when `LLM_PROVIDER=ollama`. (Default: `http://localhost:11434`)
+- `OLLAMA_MODEL`: Model name to use with Ollama when `LLM_PROVIDER=ollama`. (Default: `gpt-oss:20b`)
 - `ENABLE_UI`: If the user interface should be enabled. (Default: `false`)
 - `FIREFLY_TAG`: The tag to assign to the processed transactions. (Default: `AI categorized`)
 - `PORT`: The port where the application listens. (Default: `3000`)

--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,24 @@
             padding: 24px;
         }
 
+        .overview {
+            border: solid 1px;
+            border-radius: 5px;
+            margin-bottom: 2em;
+            padding: 24px;
+            background: #f8f8f8;
+        }
+
+        .overview ul {
+            margin: 0.5em 0 0 1.25em;
+        }
+
+        .overview__footnote {
+            margin-top: 0.75em;
+            font-size: 0.875em;
+            color: #555;
+        }
+
         pre {
             padding: 7px;
             background: #eeeeee;
@@ -43,8 +61,12 @@
 <div class="container">
     <h1>Firefly III AI Categorizer</h1>
     <section>
+        <h2>Overview</h2>
+        <div id="overview"></div>
+    </section>
+    <section>
         <h2>Jobs</h2>
-        <div id="mount"></div>
+        <div id="jobs"></div>
 <!--        <article class="job">-->
 <!--            <div><strong>Status:</strong> <span>queued</span></div>-->
 <!--            <div><strong>Created:</strong>-->
@@ -70,70 +92,176 @@
 
 <script src="/socket.io/socket.io.js"></script>
 <script>
-    let socket = io();
+    const socket = io();
 
-    const mount = document.getElementById('mount');
+    const overviewMount = document.getElementById('overview');
+    const jobsMount = document.getElementById('jobs');
+
+    const state = {
+        jobs: []
+    };
+
+    const statusOrder = [
+        {key: 'queued', label: 'Queued'},
+        {key: 'in_progress', label: 'In progress'},
+        {key: 'finished', label: 'Finished'}
+    ];
+
+    const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'medium'
+    });
+
+    const escape = (value) => {
+        if (value === null || value === undefined) {
+            return '';
+        }
+
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    };
+
+    const formatDuration = (ms) => {
+        if (!Number.isFinite(ms)) {
+            return '';
+        }
+
+        const totalSeconds = Math.max(0, Math.round(ms / 1000));
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutes = Math.floor((totalSeconds % 3600) / 60);
+        const seconds = totalSeconds % 60;
+
+        const parts = [];
+        if (hours) {
+            parts.push(`${hours}h`);
+        }
+        if (minutes) {
+            parts.push(`${minutes}m`);
+        }
+        if (!parts.length || seconds) {
+            parts.push(`${seconds}s`);
+        }
+
+        return parts.join(' ');
+    };
+
+    const setJobs = (jobs) => {
+        state.jobs = jobs
+            .slice()
+            .sort((a, b) => new Date(b.created) - new Date(a.created));
+
+        renderOverview();
+        renderJobs();
+    };
 
     socket.on('jobs', jobs => {
         console.log('jobs', jobs);
-
-        jobs.sort((a, b) => {
-            return new Date(b.created) - new Date(a.created);
-        })
-
-        jobs.forEach(job => {
-            const element = document.createElement('div');
-            element.innerHTML = renderJob(job);
-            mount.appendChild(element)
-        });
+        setJobs(jobs);
     });
 
-    socket.on('job created', e => {
-        console.log('job created', e);
-        const element = document.createElement('div');
-        element.innerHTML = renderJob(e.job);
-        mount.prepend(element);
-    })
+    socket.on('job created', event => {
+        console.log('job created', event);
+        setJobs(event.jobs ?? state.jobs);
+    });
 
-    socket.on('job updated', e => {
-        console.log('job updated', e)
+    socket.on('job updated', event => {
+        console.log('job updated', event);
+        setJobs(event.jobs ?? state.jobs);
+    });
 
-        const element = document.createElement('div');
-        element.innerHTML = renderJob(e.job);
+    const renderOverview = () => {
+        if (!state.jobs.length) {
+            overviewMount.innerHTML = '<article class="overview"><div>No tasks yet.</div></article>';
+            return;
+        }
 
-        const oldElement = document.querySelector(`[data-job-id="${e.job.id}"]`);
-        oldElement.before(element);
-        oldElement.remove();
-    })
+        const statusCounts = state.jobs.reduce((acc, job) => {
+            const status = job.status || 'queued';
+            acc[status] = (acc[status] || 0) + 1;
+            return acc;
+        }, {});
+
+        const finishedJobs = state.jobs
+            .filter(job => job.status === 'finished' && job.finishedAt)
+            .sort((a, b) => new Date(b.finishedAt) - new Date(a.finishedAt));
+
+        const durations = finishedJobs
+            .slice(0, 5)
+            .map(job => new Date(job.finishedAt) - new Date(job.created))
+            .filter(duration => Number.isFinite(duration) && duration >= 0);
+
+        const averageDuration = durations.length
+            ? durations.reduce((sum, duration) => sum + duration, 0) / durations.length
+            : null;
+
+        const remainingJobs = state.jobs.filter(job => job.status !== 'finished').length;
+        const estimatedRemaining = averageDuration !== null ? averageDuration * remainingJobs : null;
+
+        const breakdown = statusOrder
+            .map(({key, label}) => `<li>${label}: ${statusCounts[key] || 0}</li>`)
+            .join('');
+
+        overviewMount.innerHTML = `
+            <article class="overview">
+                <div><strong>Total tasks:</strong> <span>${state.jobs.length}</span></div>
+                <div><strong>Status breakdown:</strong>
+                    <ul>
+                        ${breakdown}
+                    </ul>
+                </div>
+                <div><strong>Estimated time remaining:</strong>
+                    <span>${estimatedRemaining !== null ? formatDuration(estimatedRemaining) : 'Not enough data yet'}</span>
+                </div>
+                ${averageDuration !== null ? `<div class="overview__footnote">Based on last ${durations.length} completed tasks (avg ${formatDuration(averageDuration)} each).</div>` : ''}
+            </article>
+        `;
+    };
+
+    const renderJobs = () => {
+        if (!state.jobs.length) {
+            jobsMount.innerHTML = '<p>No jobs yet.</p>';
+            return;
+        }
+
+        jobsMount.innerHTML = state.jobs.map(job => renderJob(job)).join('');
+    };
 
     const renderJob = (job) => {
-        return `<article class="job" data-job-id="${job.id}">
-            <div><strong>ID:</strong> <span>${job.id}</span></div>
-            <div><strong>Status:</strong> <span>${job.status}</span></div>
+        const created = job.created ? dateTimeFormatter.format(new Date(job.created)) : '';
+        const category = job.data?.category
+            ? escape(job.data.category)
+            : '<em>Not yet classified</em>';
+
+        return `<article class="job" data-job-id="${escape(job.id)}">
+            <div><strong>ID:</strong> <span>${escape(job.id)}</span></div>
+            <div><strong>Status:</strong> <span>${escape(job.status)}</span></div>
             <div><strong>Created:</strong>
-                <time>${Intl.DateTimeFormat(undefined, {
-            dateStyle: 'medium',
-            timeStyle: 'medium'
-        }).format(new Date(job.created))}</time>
+                <time>${created}</time>
             </div>
-            <div><strong>Destination name:</strong> <span>${job.data?.destinationName || ''}</span></div>
-            <div><strong>Description:</strong> <span>${job.data?.description || ''}</span>
-            <div><strong>Guessed category:</strong> <span>${job.data?.category ? job.data.category : '<em>Not yet classified</em>'}</span>
-            </div>
+            <div><strong>Destination name:</strong> <span>${escape(job.data?.destinationName || '')}</span></div>
+            <div><strong>Description:</strong> <span>${escape(job.data?.description || '')}</span></div>
+            <div><strong>Guessed category:</strong> <span>${category}</span></div>
             ${ job.data?.prompt ? `<div><strong>Prompt:</strong><br>
                 <details>
                     <summary>Show</summary>
-                    <pre>${job.data.prompt}</pre>
+                    <pre>${escape(job.data.prompt)}</pre>
                 </details>
             </div>` : ''}
-            ${ job.data?.response ? `<div><strong>Open AI's response:</strong>
+            ${ job.data?.response ? `<div><strong>Model response:</strong>
                  <details>
                     <summary>Show</summary>
-                    <pre>${job.data.response}</pre>
+                    <pre>${escape(job.data.response)}</pre>
                  </details>
             </div>` : ''}
-        </article>`
-    }
+        </article>`;
+    };
+
+    renderOverview();
+    renderJobs();
 </script>
 </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import express from "express";
 import {getConfigVariable} from "./util.js";
 import FireflyService from "./FireflyService.js";
-import OpenAiService from "./OpenAiService.js";
+import createLlmService from "./LlmServiceFactory.js";
 import {Server} from "socket.io";
 import * as http from "http";
 import Queue from "queue";
@@ -12,7 +12,7 @@ export default class App {
     #ENABLE_UI;
 
     #firefly;
-    #openAi;
+    #llmService;
 
     #server;
     #io;
@@ -29,7 +29,7 @@ export default class App {
 
     async run() {
         this.#firefly = new FireflyService();
-        this.#openAi = new OpenAiService();
+        this.#llmService = createLlmService();
 
         this.#queue = new Queue({
             timeout: 30 * 1000,
@@ -56,6 +56,9 @@ export default class App {
             this.#express.use('/', express.static('public'))
         }
 
+        this.#express.get('/webhook', (req, res) => {
+            res.status(200).send('Webhook endpoint is ready to receive POST requests.');
+        });
         this.#express.post('/webhook', this.#onWebhook.bind(this))
 
         this.#server.listen(this.#PORT, async () => {
@@ -82,12 +85,18 @@ export default class App {
     #handleWebhook(req, res) {
         // TODO: validate auth
 
-        if (req.body?.trigger !== "STORE_TRANSACTION") {
-            throw new WebhookException("trigger is not STORE_TRANSACTION. Request will not be processed");
+        const trigger = req.body?.trigger;
+        const allowedTriggers = new Set([
+            "STORE_TRANSACTION",
+            "AFTER_TRANSACTION_CREATE",
+        ]);
+
+        if (!allowedTriggers.has(trigger)) {
+            throw new WebhookException("trigger is not STORE_TRANSACTION or AFTER_TRANSACTION_CREATE. Request will not be processed");
         }
 
         if (req.body?.response !== "TRANSACTIONS") {
-            throw new WebhookException("trigger is not TRANSACTION. Request will not be processed");
+            throw new WebhookException("response is not TRANSACTIONS. Request will not be processed");
         }
 
         if (!req.body?.content?.id) {
@@ -115,12 +124,16 @@ export default class App {
             throw new WebhookException("Missing content.transactions[0].destination_name");
         }
 
-        const destinationName = req.body.content.transactions[0].destination_name;
-        const description = req.body.content.transactions[0].description
+        const transaction = req.body.content.transactions[0];
+        const destinationName = transaction.destination_name;
+        const description = transaction.description
 
         const job = this.#jobList.createJob({
             destinationName,
-            description
+            description,
+            amount: transaction.amount,
+            currency: transaction.currency_code || transaction.foreign_currency_code,
+            date: transaction.date
         });
 
         this.#queue.push(async () => {
@@ -128,7 +141,7 @@ export default class App {
 
             const categories = await this.#firefly.getCategories();
 
-            const {category, prompt, response} = await this.#openAi.classify(Array.from(categories.keys()), destinationName, description)
+            const {category, prompt, response} = await this.#llmService.classify(Array.from(categories.keys()), transaction)
 
             const newData = Object.assign({}, job.data);
             newData.category = category;

--- a/src/JobList.js
+++ b/src/JobList.js
@@ -24,6 +24,8 @@ export default class JobList {
             id,
             created,
             status: "queued",
+            startedAt: null,
+            finishedAt: null,
             data,
         }
 
@@ -42,12 +44,14 @@ export default class JobList {
     setJobInProgress(id) {
         const job = this.#jobs.get(id);
         job.status = "in_progress";
+        job.startedAt = new Date();
         this.#eventEmitter.emit('job updated', {job, jobs: Array.from(this.#jobs.values())});
     }
 
     setJobFinished(id) {
         const job = this.#jobs.get(id);
         job.status = "finished";
+        job.finishedAt = new Date();
         this.#eventEmitter.emit('job updated', {job, jobs: Array.from(this.#jobs.values())});
     }
 }

--- a/src/LlmServiceFactory.js
+++ b/src/LlmServiceFactory.js
@@ -1,0 +1,15 @@
+import {getConfigVariable} from "./util.js";
+import OpenAiService from "./OpenAiService.js";
+import OllamaService from "./OllamaService.js";
+
+export default function createLlmService() {
+    const provider = getConfigVariable("LLM_PROVIDER", "openai").toLowerCase();
+
+    switch (provider) {
+        case "ollama":
+            return new OllamaService();
+        case "openai":
+        default:
+            return new OpenAiService();
+    }
+}

--- a/src/OllamaService.js
+++ b/src/OllamaService.js
@@ -1,0 +1,154 @@
+import {getConfigVariable} from "./util.js";
+
+export default class OllamaService {
+    #baseUrl;
+    #model;
+
+    constructor() {
+        this.#baseUrl = getConfigVariable("OLLAMA_URL", "http://localhost:11434");
+        this.#model = getConfigVariable("OLLAMA_MODEL", "gpt-oss:20b");
+    }
+
+    async classify(categories, transaction) {
+        const prompt = this.#generatePrompt(categories, transaction);
+
+        try {
+            const response = await fetch(`${this.#baseUrl}/api/generate`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify({
+                    model: this.#model,
+                    prompt,
+                    stream: false
+                })
+            });
+
+            if (!response.ok) {
+                throw new OllamaException(response.status, response, await response.text());
+            }
+
+            const data = await response.json();
+            const rawResponse = data.response ?? "";
+            const guess = this.#extractCategory(rawResponse, categories);
+
+            if (!guess) {
+                console.warn(`Ollama could not classify the transaction.
+                Prompt: ${prompt}
+                Ollama response: ${rawResponse}`)
+            }
+
+            return {
+                prompt,
+                response: rawResponse,
+                category: guess
+            };
+        } catch (error) {
+            if (error instanceof OllamaException) {
+                throw error;
+            }
+
+            console.error(error.message);
+            throw new OllamaException(null, null, error.message);
+        }
+    }
+
+    #generatePrompt(categories, transaction) {
+        const details = this.#formatTransactionDetails(transaction);
+        return `You are an assistant that classifies personal finance transactions.
+Available categories: ${categories.join(", ")}.
+The transaction details are:
+${details}
+Return only the single category name that best fits.`;
+    }
+
+    #formatTransactionDetails(transaction) {
+        const lines = [];
+
+        const simpleFields = {
+            "Description": transaction.description,
+            "Destination": transaction.destination_name,
+            "Source": transaction.source_name,
+            "Amount": transaction.amount,
+            "Currency": transaction.currency_code || transaction.foreign_currency_code,
+            "Foreign amount": transaction.foreign_amount,
+            "Date": transaction.date,
+            "Budget": transaction.budget_name,
+            "Bill": transaction.bill_name,
+            "Notes": transaction.notes,
+            "Payment reference": transaction.payment_reference,
+        };
+
+        Object.entries(simpleFields).forEach(([label, value]) => {
+            if (value) {
+                lines.push(`${label}: ${value}`);
+            }
+        });
+
+        if (transaction.tags && transaction.tags.length > 0) {
+            lines.push(`Tags: ${transaction.tags.join(", ")}`);
+        }
+
+        if (transaction.category_name) {
+            lines.push(`Current category name: ${transaction.category_name}`);
+        }
+
+        return lines.join("\n");
+    }
+
+    #extractCategory(rawResponse, categories) {
+        if (!rawResponse) {
+            return null;
+        }
+
+        const normalizedCategories = categories.map(category => category.toLowerCase());
+
+        const lines = rawResponse.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+
+        for (const line of lines) {
+            const normalizedLine = line.toLowerCase();
+            const exactIndex = normalizedCategories.indexOf(normalizedLine);
+            if (exactIndex !== -1) {
+                return categories[exactIndex];
+            }
+
+            const containedIndex = normalizedCategories.findIndex(category => normalizedLine.includes(category));
+            if (containedIndex !== -1) {
+                return categories[containedIndex];
+            }
+        }
+
+        // fallback: try to match first word ignoring punctuation
+        const cleaned = lines[0]?.replace(/[^\w\s]/g, "").toLowerCase();
+        if (!cleaned) {
+            return null;
+        }
+
+        const fallbackIndex = normalizedCategories.indexOf(cleaned);
+        if (fallbackIndex !== -1) {
+            return categories[fallbackIndex];
+        }
+
+        const containsFallbackIndex = normalizedCategories.findIndex(category => cleaned.includes(category));
+        if (containsFallbackIndex !== -1) {
+            return categories[containsFallbackIndex];
+        }
+
+        return null;
+    }
+}
+
+class OllamaException extends Error {
+    code;
+    response;
+    body;
+
+    constructor(statusCode, response, body) {
+        super(`Error while communicating with Ollama: ${statusCode} - ${body}`);
+
+        this.code = statusCode;
+        this.response = response;
+        this.body = body;
+    }
+}

--- a/src/OpenAiService.js
+++ b/src/OpenAiService.js
@@ -15,9 +15,9 @@ export default class OpenAiService {
         this.#openAi = new OpenAIApi(configuration)
     }
 
-    async classify(categories, destinationName, description) {
+    async classify(categories, transaction) {
         try {
-            const prompt = this.#generatePrompt(categories, destinationName, description);
+            const prompt = this.#generatePrompt(categories, transaction.destination_name, transaction.description);
 
             const response = await this.#openAi.createCompletion({
                 model: this.#model,


### PR DESCRIPTION
## Summary
- add a factory that selects the LLM provider based on configuration
- implement an Ollama-backed classifier that shares richer transaction details
- document the new configuration options and privacy differences for self-hosted models
- accept the Firefly "After transaction creation" webhook trigger and correct the response validation message
- add a GET handler to `/webhook` so health checks return a helpful response
- track job progress timestamps and surface an overview card with queue counts plus an estimated remaining time on the UI

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d8f2ce8bd8832da9fd64ebe92ac0b2